### PR TITLE
Fix decoder to handle escapes correctly

### DIFF
--- a/decode.lisp
+++ b/decode.lisp
@@ -163,7 +163,7 @@
             (let ((c (case (read-char stream)
                        (#\n #\newline)
                        (#\t #\tab)
-                       (#\f #\formfeed)
+                       (#\f #\page)
                        (#\b #\backspace)
                        (#\r #\return)
 

--- a/decode.lisp
+++ b/decode.lisp
@@ -160,25 +160,26 @@
        ;; write character to output
        do (if (char/= c #\\)
               (write-char c s)
-            (let ((c (case (read-char stream)
-                       (#\n #\newline)
-                       (#\t #\tab)
-                       (#\f #\page)
-                       (#\b #\backspace)
-                       (#\r #\return)
+            (let* ((c2 (read-char stream))
+                   (c (case c2
+                        (#\n #\newline)
+                        (#\t #\tab)
+                        (#\f #\page)
+                        (#\b #\backspace)
+                        (#\r #\return)
 
-                       ;; read unicode character
-                       (#\u (let ((x1 (digit-char-p (read-char stream) 16))
-                                  (x2 (digit-char-p (read-char stream) 16))
-                                  (x3 (digit-char-p (read-char stream) 16))
-                                  (x4 (digit-char-p (read-char stream) 16)))
-                              (code-char (logior (ash x1 12)
-                                                 (ash x2  8)
-                                                 (ash x3  4)
-                                                 (ash x4  0)))))
+                        ;; read unicode character
+                        (#\u (let ((x1 (digit-char-p (read-char stream) 16))
+                                   (x2 (digit-char-p (read-char stream) 16))
+                                   (x3 (digit-char-p (read-char stream) 16))
+                                   (x4 (digit-char-p (read-char stream) 16)))
+                               (code-char (logior (ash x1 12)
+                                                  (ash x2  8)
+                                                  (ash x3  4)
+                                                  (ash x4  0)))))
 
-                       ;; verbatim character
-                       (otherwise c))))
+                        ;; verbatim character
+                        (otherwise c2))))
               (write-char c s))))))
 
 ;;; ----------------------------------------------------

--- a/encode.lisp
+++ b/encode.lisp
@@ -61,7 +61,7 @@
             ((char= c #\") "\\\"")
             ((char= c #\newline) "\\n")
             ((char= c #\tab) "\\t")
-            ((char= c #\formfeed) "\\f")
+            ((char= c #\page) "\\f")
             ((char= c #\backspace) "\\b")
             ((char= c #\return) "\\r")
             ((char> c #\~)


### PR DESCRIPTION
I wonder if you would consider this PR. this tries to fix some problems I found.

# Change `#\formfeed` to `#\page`

When trying to load this library by Allegro CL, I saw an error reading `#\formfeed`.
I confirmed SBCL can read it and means same with `#\page`.

I think changing it to `#\page` makes this library more portable.

(commit c3e9cf374119543a4ffebf8248613d856f6bc540)

# Fixes decoder around treating escapes 

I found `json-read-string` sometimes emits `\\` even when `\"` appeares.

The next example tries to read a string `k"l`

```
CL-USER> (with-input-from-string (in "\"k\\\"l\"") (boost-json::json-read-string in))
"k\\l"
```

I think the second character of the result should be `"`, like this:

```
CL-USER> (cl-json:decode-json-from-string "\"k\\\"l\"")
"k\"l"
```

I found the result of `read-char` after `\` is not used on the `otherwise` clause. This fix tries to reuse it.

(commit 54287bcb9755a394bace2d23550a7c9f952b88c6)
